### PR TITLE
Add query support for DateTimeOffset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ solution: Pomona.sln
 sudo: false
 install:
  - nuget restore Pomona.sln
- - nuget install NUnit.Runners -Version 3.2.0 -OutputDirectory ./packages
+ - nuget install NUnit.Runners -Version 3.5.0 -OutputDirectory ./packages
 script:
  - xbuild Pomona.sln /property:Configuration="Release" /verbosity:detailed
- - mono ./packages/NUnit.ConsoleRunner.3.2.0/tools/nunit3-console.exe ./tests/Pomona.UnitTests/bin/Release/Pomona.UnitTests.dll ./tests/Pomona.SystemTests/bin/Release/Pomona.SystemTests.dll --where "cat != TODO && cat != WindowsRequired"
+ - mono ./packages/NUnit.ConsoleRunner.3.5.0/tools/nunit3-console.exe ./tests/Pomona.UnitTests/bin/Release/Pomona.UnitTests.dll ./tests/Pomona.SystemTests/bin/Release/Pomona.SystemTests.dll --where "cat != TODO && cat != WindowsRequired"
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ solution: Pomona.sln
 sudo: false
 install:
  - nuget restore Pomona.sln
- - nuget install NUnit.Runners -Version 3.5.0 -OutputDirectory ./packages
 script:
  - xbuild Pomona.sln /property:Configuration="Release" /verbosity:detailed
  - mono ./packages/NUnit.ConsoleRunner.3.5.0/tools/nunit3-console.exe ./tests/Pomona.UnitTests/bin/Release/Pomona.UnitTests.dll ./tests/Pomona.SystemTests/bin/Release/Pomona.SystemTests.dll --where "cat != TODO && cat != WindowsRequired"

--- a/Pomona.sln.DotSettings
+++ b/Pomona.sln.DotSettings
@@ -699,8 +699,9 @@ project's repository, or alternatively at http://pomona.io/</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/UnitTesting/DisabledProviders/=NUnit2x/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/Environment/UnitTesting/ExcludedCategoriesList/@EntryValue">TODO</s:String>
-    <s:String x:Key="/Default/Environment/UnitTesting/NUnitProvider/CustomNUnitFolder/@EntryValue">C:\Programs\NUnit-2.6.3\bin\lib</s:String>
+    <s:String x:Key="/Default/Environment/UnitTesting/NUnitProvider/CustomNUnitFolder/@EntryValue">..\Pomona\packages\NUnit.ConsoleRunner.3.5.0\tools</s:String>
     <s:String x:Key="/Default/Environment/UnitTesting/NUnitProvider/UseAddins/@EntryValue">Always</s:String>
 	<s:String x:Key="/Default/Environment/UnitTesting/NUnitProvider/UseNUnit3/@EntryValue">Always</s:String>
     <s:Int64 x:Key="/Default/Environment/UnitTesting/ParallelProcessesCount/@EntryValue">5</s:Int64>

--- a/app/Pomona.Common/Internals/GenericInvoker.cs
+++ b/app/Pomona.Common/Internals/GenericInvoker.cs
@@ -268,10 +268,9 @@ namespace Pomona.Common.Internals
 
         public T GetDelegate(Type[] typeArgs)
         {
-            return this.methodInstanceCache.GetOrAdd(typeArgs,
-                                                     k =>
-                                                         CreateCallWrapper(this.methodDefinition.MakeGenericMethod(k), inArgs, delReturnType)
-                                                         .Compile());
+            return this.methodInstanceCache
+                       .GetOrAdd(typeArgs,
+                                 k => CreateCallWrapper(this.methodDefinition.MakeGenericMethod(k), inArgs, delReturnType).Compile());
         }
 
 

--- a/app/Pomona.Common/Internals/TypeUtils.cs
+++ b/app/Pomona.Common/Internals/TypeUtils.cs
@@ -96,7 +96,9 @@ namespace Pomona.Common.Internals
         public static Type[] GetTypes<T1, T2, T3, T4, T5, T6, T7, T8>()
         {
             return new[]
-            { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8) };
+            {
+                typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8)
+            };
         }
 
 

--- a/app/Pomona.Common/Internals/TypeUtils.cs
+++ b/app/Pomona.Common/Internals/TypeUtils.cs
@@ -23,6 +23,7 @@ namespace Pomona.Common.Internals
             typeof(float),
             typeof(decimal),
             typeof(DateTime),
+            typeof(DateTimeOffset),
             typeof(object),
             typeof(bool),
             typeof(Guid),

--- a/app/Pomona.Common/Linq/NonGeneric/QueryableNonGenericExtensions.cs
+++ b/app/Pomona.Common/Linq/NonGeneric/QueryableNonGenericExtensions.cs
@@ -20,6 +20,7 @@ namespace Pomona.Common.Linq.NonGeneric
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
+
             if (projection == null)
                 throw new ArgumentNullException(nameof(projection));
 
@@ -31,14 +32,15 @@ namespace Pomona.Common.Linq.NonGeneric
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
+
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
-            return source.Provider.CreateQuery(
-                Expression.Call(
-                    null,
-                    QueryableMethods.GroupBy.MakeGenericMethod(source.ElementType, keySelector.ReturnType),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector) }
-                    ));
+
+            var method = QueryableMethods.GroupBy.MakeGenericMethod(source.ElementType, keySelector.ReturnType);
+            var quotedKeySelector = Expression.Quote(keySelector);
+            var arguments = new[] { source.Expression, quotedKeySelector };
+            var methodCallExpression = Expression.Call(null, method, arguments);
+            return source.Provider.CreateQuery(methodCallExpression);
         }
 
 
@@ -49,12 +51,10 @@ namespace Pomona.Common.Linq.NonGeneric
             if (resultType == null)
                 throw new ArgumentNullException(nameof(resultType));
 
-            return source.Provider.CreateQuery(
-                Expression.Call(
-                    null,
-                    (QueryableMethods.OfType).MakeGenericMethod(resultType),
-                    new Expression[] { source.Expression }
-                    ));
+            var method = QueryableMethods.OfType.MakeGenericMethod(resultType);
+            var arguments = source.Expression;
+            var methodCallExpression = Expression.Call(null, method, arguments);
+            return source.Provider.CreateQuery(methodCallExpression);
         }
 
 
@@ -62,8 +62,10 @@ namespace Pomona.Common.Linq.NonGeneric
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
+
             if (resultType == null)
                 throw new ArgumentNullException(nameof(resultType));
+
             if (source.ElementType == resultType)
                 return source;
 
@@ -75,15 +77,15 @@ namespace Pomona.Common.Linq.NonGeneric
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
+
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return (IOrderedQueryable)source.Provider.CreateQuery(
-                Expression.Call(
-                    null,
-                    (QueryableMethods.OrderBy).MakeGenericMethod(source.ElementType, keySelector.ReturnType),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector) }
-                    ));
+            var method = QueryableMethods.OrderBy.MakeGenericMethod(source.ElementType, keySelector.ReturnType);
+            var quotedKeySelector = Expression.Quote(keySelector);
+            var arguments = new Expression[] { source.Expression, quotedKeySelector };
+            var methodCallExpression = Expression.Call(null, method, arguments);
+            return (IOrderedQueryable)source.Provider.CreateQuery(methodCallExpression);
         }
 
 
@@ -93,6 +95,7 @@ namespace Pomona.Common.Linq.NonGeneric
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
+
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
@@ -106,15 +109,15 @@ namespace Pomona.Common.Linq.NonGeneric
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
+
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return (IOrderedQueryable)source.Provider.CreateQuery(
-                Expression.Call(
-                    null,
-                    (QueryableMethods.OrderByDescending).MakeGenericMethod(source.ElementType, keySelector.ReturnType),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector) }
-                    ));
+            var method = QueryableMethods.OrderByDescending.MakeGenericMethod(source.ElementType, keySelector.ReturnType);
+            var quotedKeySelector = Expression.Quote(keySelector);
+            var arguments = new[] { source.Expression, quotedKeySelector };
+            var methodCallExpression = Expression.Call(null, method, arguments);
+            return (IOrderedQueryable)source.Provider.CreateQuery(methodCallExpression);
         }
 
 
@@ -122,14 +125,15 @@ namespace Pomona.Common.Linq.NonGeneric
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
+
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
-            return source.Provider.CreateQuery(
-                Expression.Call(
-                    null,
-                    (QueryableMethods.Select).MakeGenericMethod(source.ElementType, selector.ReturnType),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
-                    ));
+
+            var quotedSelector = Expression.Quote(selector);
+            var arguments = new[] { source.Expression, quotedSelector };
+            var method = QueryableMethods.Select.MakeGenericMethod(source.ElementType, selector.ReturnType);
+            var methodCallExpression = Expression.Call(null, method, arguments);
+            return source.Provider.CreateQuery(methodCallExpression);
         }
 
 
@@ -137,17 +141,19 @@ namespace Pomona.Common.Linq.NonGeneric
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
+
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
+
             Type selectorItemType;
             if (!selector.ReturnType.TryGetEnumerableElementType(out selectorItemType))
                 throw new ArgumentException("The return type of selector is not an IEnumerable<T>", nameof(selector));
-            return source.Provider.CreateQuery(
-                Expression.Call(
-                    null,
-                    (QueryableMethods.SelectMany).MakeGenericMethod(source.ElementType, selectorItemType),
-                    new Expression[] { source.Expression, Expression.Quote(selector) }
-                    ));
+
+            var method = QueryableMethods.SelectMany.MakeGenericMethod(source.ElementType, selectorItemType);
+            var quotedSelector = Expression.Quote(selector);
+            var arguments = new[] { source.Expression, quotedSelector };
+            var methodCallExpression = Expression.Call(null, method, arguments);
+            return source.Provider.CreateQuery(methodCallExpression);
         }
 
 
@@ -155,12 +161,12 @@ namespace Pomona.Common.Linq.NonGeneric
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
-            return source.Provider.CreateQuery(
-                Expression.Call(
-                    null,
-                    QueryableMethods.Skip.MakeGenericMethod(source.ElementType),
-                    new Expression[] { source.Expression, Expression.Constant(count) }
-                    ));
+
+            var countExpression = Expression.Constant(count);
+            var arguments = new[] { source.Expression, countExpression };
+            var method = QueryableMethods.Skip.MakeGenericMethod(source.ElementType);
+            var methodCallExpression = Expression.Call(null, method, arguments);
+            return source.Provider.CreateQuery(methodCallExpression);
         }
 
 
@@ -177,6 +183,7 @@ namespace Pomona.Common.Linq.NonGeneric
                                                      null);
             if (method == null)
                 throw new NotSupportedException("Unable to apply Sum to " + iqType);
+
             return method.Invoke(null, new object[] { source });
         }
 
@@ -185,12 +192,12 @@ namespace Pomona.Common.Linq.NonGeneric
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
-            return source.Provider.CreateQuery(
-                Expression.Call(
-                    null,
-                    QueryableMethods.Take.MakeGenericMethod(source.ElementType),
-                    new Expression[] { source.Expression, Expression.Constant(count) }
-                    ));
+
+            var method = QueryableMethods.Take.MakeGenericMethod(source.ElementType);
+            var countExpression = Expression.Constant(count);
+            var arguments = new[] { source.Expression, countExpression };
+            var methodCallExpression = Expression.Call(null, method, arguments);
+            return source.Provider.CreateQuery(methodCallExpression);
         }
 
 
@@ -198,15 +205,14 @@ namespace Pomona.Common.Linq.NonGeneric
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
+
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return (IOrderedQueryable)source.Provider.CreateQuery(
-                Expression.Call(
-                    null,
-                    (QueryableMethods.ThenBy).MakeGenericMethod(source.ElementType, keySelector.ReturnType),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector) }
-                    ));
+            var arguments = new[] { source.Expression, Expression.Quote(keySelector) };
+            var method = QueryableMethods.ThenBy.MakeGenericMethod(source.ElementType, keySelector.ReturnType);
+            var methodCallExpression = Expression.Call(null, method, arguments);
+            return (IOrderedQueryable)source.Provider.CreateQuery(methodCallExpression);
         }
 
 
@@ -216,10 +222,13 @@ namespace Pomona.Common.Linq.NonGeneric
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
+
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return sortOrder == SortOrder.Descending ? source.ThenByDescending(keySelector) : source.ThenBy(keySelector);
+            return sortOrder == SortOrder.Descending
+                ? source.ThenByDescending(keySelector)
+                : source.ThenBy(keySelector);
         }
 
 
@@ -227,15 +236,15 @@ namespace Pomona.Common.Linq.NonGeneric
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
+
             if (keySelector == null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            return (IOrderedQueryable)source.Provider.CreateQuery(
-                Expression.Call(
-                    null,
-                    (QueryableMethods.ThenByDescending).MakeGenericMethod(source.ElementType, keySelector.ReturnType),
-                    new Expression[] { source.Expression, Expression.Quote(keySelector) }
-                    ));
+            var method = QueryableMethods.ThenByDescending.MakeGenericMethod(source.ElementType, keySelector.ReturnType);
+            var quotedKeySelector = Expression.Quote(keySelector);
+            var arguments = new[] { source.Expression, quotedKeySelector };
+            var methodCallExpression = Expression.Call(null, method, arguments);
+            return (IOrderedQueryable)source.Provider.CreateQuery(methodCallExpression);
         }
 
 
@@ -243,14 +252,15 @@ namespace Pomona.Common.Linq.NonGeneric
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
+
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
-            return source.Provider.CreateQuery(
-                Expression.Call(
-                    null,
-                    (QueryableMethods.Where).MakeGenericMethod(source.ElementType),
-                    new Expression[] { source.Expression, Expression.Quote(predicate) }
-                    ));
+
+            var method = QueryableMethods.Where.MakeGenericMethod(source.ElementType);
+            var quotedPredicate = Expression.Quote(predicate);
+            var arguments = new[] { source.Expression, quotedPredicate };
+            var methodCallExpression = Expression.Call(null, method, arguments);
+            return source.Provider.CreateQuery(methodCallExpression);
         }
     }
 }

--- a/app/Pomona.Common/Linq/QueryPredicateBuilder.cs
+++ b/app/Pomona.Common/Linq/QueryPredicateBuilder.cs
@@ -507,12 +507,12 @@ namespace Pomona.Common.Linq
                     return ((decimal)value).ToString(CultureInfo.InvariantCulture) + "m";
                 case TypeCode.Object:
                     if (value is Guid)
-                        return $"guid'{((Guid)value)}'";
+                        return $"guid'{(Guid)value}'";
                     if (value is Type)
                         return GetExternalTypeName((Type)value);
                     break;
                 case TypeCode.Boolean:
-                    return ((bool)value) ? "true" : "false";
+                    return (bool)value ? "true" : "false";
                 default:
                     break;
             }
@@ -723,11 +723,10 @@ namespace Pomona.Common.Linq
         }
 
 
-        private bool TryMapKnownOdataFunction(
-            Expression origNode,
-            MemberInfo member,
-            IEnumerable<Expression> arguments,
-            out Expression odataExpression)
+        private bool TryMapKnownOdataFunction(Expression origNode,
+                                              MemberInfo member,
+                                              IEnumerable<Expression> arguments,
+                                              out Expression odataExpression)
         {
             ReplaceQueryableMethodWithCorrespondingEnumerableMethod(ref member, ref arguments);
 

--- a/app/Pomona.Common/Linq/QueryPredicateBuilder.cs
+++ b/app/Pomona.Common/Linq/QueryPredicateBuilder.cs
@@ -517,8 +517,12 @@ namespace Pomona.Common.Linq
                     break;
             }
 
+            if (typeof(DateTimeOffset).IsAssignableFrom(valueType))
+                return $"datetime'{(DateTimeOffset)value:yyyy-MM-ddTHH:mm:sszzzz}'";
+
             if (typeof(IStringEnum).IsAssignableFrom(valueType))
                 return EncodeString(value.ToString());
+
             return null;
         }
 

--- a/app/Pomona.Common/Linq/QueryPredicateBuilder.cs
+++ b/app/Pomona.Common/Linq/QueryPredicateBuilder.cs
@@ -518,7 +518,7 @@ namespace Pomona.Common.Linq
             }
 
             if (typeof(DateTimeOffset).IsAssignableFrom(valueType))
-                return $"datetime'{(DateTimeOffset)value:yyyy-MM-ddTHH:mm:sszzzz}'";
+                return $"datetime'{(DateTimeOffset)value:O}'";
 
             if (typeof(IStringEnum).IsAssignableFrom(valueType))
                 return EncodeString(value.ToString());

--- a/app/Pomona.Common/Serialization/Json/PomonaJsonDeserializer.cs
+++ b/app/Pomona.Common/Serialization/Json/PomonaJsonDeserializer.cs
@@ -519,10 +519,10 @@ namespace Pomona.Common.Serialization.Json
                 }
 
                 var context = this.contextProvider.GetDeserializationContext(options);
-                return Deserialize(textReader,
-                                   returnTypeSpecified ? context.GetClassMapping(options.ExpectedBaseType) : null,
-                                   context,
-                                   options.Target);
+                var expectedBaseType = returnTypeSpecified
+                    ? context.GetClassMapping(options.ExpectedBaseType)
+                    : null;
+                return Deserialize(textReader, expectedBaseType, context, options.Target);
             }
             catch (JsonSerializationException jsonEx)
             {

--- a/app/Pomona.Common/TypeExtensions.cs
+++ b/app/Pomona.Common/TypeExtensions.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -19,11 +20,21 @@ namespace Pomona.Common
 {
     public static class TypeExtensions
     {
-        public static string CodeBaseAbsolutePath(this Assembly assembly)
+        public static string GetPhysicalLocation(this Assembly assembly)
         {
             if (assembly == null)
                 throw new ArgumentNullException(nameof(assembly));
-            return new Uri(assembly.CodeBase).AbsolutePath;
+
+            var assemblyPath = assembly.Location;
+
+            if (String.IsNullOrEmpty(assemblyPath))
+            {
+                var uri = new UriBuilder(assembly.CodeBase);
+                var unescapeDataString = Uri.UnescapeDataString(uri.Path);
+                assemblyPath = Path.GetFullPath(unescapeDataString);
+            }
+
+            return assemblyPath;
         }
 
 

--- a/app/Pomona/Pomona.csproj
+++ b/app/Pomona/Pomona.csproj
@@ -175,6 +175,7 @@
     <Compile Include="PomonaSession.cs" />
     <Compile Include="PomonaSessionExtensions.cs" />
     <Compile Include="PomonaSessionFactory.cs" />
+    <Compile Include="Queries\DateTimeOffsetNode.cs" />
     <Compile Include="Queries\DefaultQueryExecutor.cs" />
     <Compile Include="Queries\IQueryableResolver.cs" />
     <Compile Include="Queries\IQueryExecutor.cs" />

--- a/app/Pomona/PomonaContext.cs
+++ b/app/Pomona/PomonaContext.cs
@@ -120,13 +120,14 @@ namespace Pomona
 
             using (var textReader = new StreamReader(Request.Body))
             {
-                return Session.GetInstance<ITextDeserializer>().Deserialize(textReader,
-                                                                            new DeserializeOptions()
-                                                                            {
-                                                                                Target = patchedObject,
-                                                                                ExpectedBaseType = expectedBaseType,
-                                                                                TargetNode = Node
-                                                                            });
+                var deserializer = Session.GetInstance<ITextDeserializer>();
+                var options = new DeserializeOptions()
+                {
+                    Target = patchedObject,
+                    ExpectedBaseType = expectedBaseType,
+                    TargetNode = Node
+                };
+                return deserializer.Deserialize(textReader, options);
             }
         }
 

--- a/app/Pomona/PomonaModule.cs
+++ b/app/Pomona/PomonaModule.cs
@@ -212,7 +212,8 @@ namespace Pomona
             {
                 try
                 {
-                    var pomonaResponse = (PomonaResponse)handler(x);
+                    var response = handler(x);
+                    var pomonaResponse = (PomonaResponse)response;
 
                     if ((int)pomonaResponse.StatusCode >= 400)
                         SetErrorHandled();
@@ -226,9 +227,8 @@ namespace Pomona
                         throw;
 
                     SetErrorHandled();
-                    return new PomonaResponse(error.Entity ?? PomonaResponse.NoBodyEntity,
-                                              error.StatusCode,
-                                              responseHeaders : error.ResponseHeaders);
+                    var entity = error.Entity ?? PomonaResponse.NoBodyEntity;
+                    return new PomonaResponse(entity, error.StatusCode, responseHeaders : error.ResponseHeaders);
                 }
             };
         }
@@ -318,8 +318,10 @@ namespace Pomona
             {
                 if (typeof(T) == GetType())
                     return (T)((object)this.module);
+
                 if (typeof(T) == typeof(IPomonaDataSource) && this.dataSource != null)
                     return (T)this.dataSource;
+
                 if (typeof(T) == typeof(IPomonaErrorHandler))
                     return (T)((object)this.module);
 

--- a/app/Pomona/PomonaQuery.cs
+++ b/app/Pomona/PomonaQuery.cs
@@ -102,8 +102,12 @@ namespace Pomona
 
                 if (skipAndTakeAfterExecute)
                 {
-                    limitedQueryable =
-                        ((IEnumerable)queryable).Cast<object>().Skip(Skip).Take(Top).Cast(queryable.ElementType).ToListDetectType();
+                    limitedQueryable = ((IEnumerable)queryable)
+                        .Cast<object>()
+                        .Skip(Skip)
+                        .Take(Top)
+                        .Cast(queryable.ElementType)
+                        .ToListDetectType();
                 }
                 else
                 {

--- a/app/Pomona/Queries/DateTimeOffsetNode.cs
+++ b/app/Pomona/Queries/DateTimeOffsetNode.cs
@@ -1,0 +1,19 @@
+﻿#region License
+
+// Pomona is open source software released under the terms of the LICENSE specified in the
+// project's repository, or alternatively at http://pomona.io/
+
+#endregion
+
+using System;
+
+namespace Pomona.Queries
+{
+    internal class DateTimeOffsetNode : LiteralNode<DateTimeOffset>
+    {
+        public DateTimeOffsetNode(DateTimeOffset value)
+            : base(NodeType.DateTimeOffsetLiteral, value)
+        {
+        }
+    }
+}

--- a/app/Pomona/Queries/NodeTreeToExpressionConverter.cs
+++ b/app/Pomona/Queries/NodeTreeToExpressionConverter.cs
@@ -324,6 +324,12 @@ namespace Pomona.Queries
                 return Expression.Constant(dateTimeNode.Value);
             }
 
+            if (node.NodeType == NodeType.DateTimeOffsetLiteral)
+            {
+                var dateTimeOffsetNode = (DateTimeOffsetNode)node;
+                return Expression.Constant(dateTimeOffsetNode.Value);
+            }
+
             if (node.NodeType == NodeType.StringLiteral)
             {
                 var stringNode = (StringNode)node;

--- a/app/Pomona/Queries/NodeTreeToExpressionConverter.cs
+++ b/app/Pomona/Queries/NodeTreeToExpressionConverter.cs
@@ -65,26 +65,26 @@ namespace Pomona.Queries
         }
 
 
-        public LambdaExpression ToLambdaExpression(
-            ParameterExpression thisParam,
-            IEnumerable<ParameterExpression> lamdbaParameters,
-            IEnumerable<ParameterExpression> outerParameters,
-            NodeBase node)
+        public LambdaExpression ToLambdaExpression(ParameterExpression thisParameter,
+                                                   IEnumerable<ParameterExpression> lamdbaParameters,
+                                                   IEnumerable<ParameterExpression> outerParameters,
+                                                   NodeBase node)
         {
-            if (thisParam == null)
-                throw new ArgumentNullException(nameof(thisParam));
+            if (thisParameter == null)
+                throw new ArgumentNullException(nameof(thisParameter));
+
             if (lamdbaParameters == null)
                 throw new ArgumentNullException(nameof(lamdbaParameters));
             try
             {
-                this.thisParam = thisParam;
-                this.parameters =
-                    lamdbaParameters
-                        .Where(x => x != thisParam)
+                this.thisParam = thisParameter;
+                var parameterList = lamdbaParameters as IList<ParameterExpression> ?? lamdbaParameters.ToList();
+                this.parameters = parameterList
+                        .Where(x => x != thisParameter)
                         .Concat(outerParameters ?? Enumerable.Empty<ParameterExpression>())
                         .ToDictionary(x => x.Name, x => x);
 
-                return Expression.Lambda(ParseExpression(node), lamdbaParameters);
+                return Expression.Lambda(ParseExpression(node), parameterList);
             }
             finally
             {
@@ -99,7 +99,7 @@ namespace Pomona.Queries
                                                QueryParseErrorReason? errorReason = null,
                                                string memberName = null)
         {
-            if (node != null && node.ParserNode != null && this.parsedString != null)
+            if (node?.ParserNode != null && this.parsedString != null)
             {
                 return QueryParseException.Create(node.ParserNode,
                                                   message,
@@ -123,7 +123,7 @@ namespace Pomona.Queries
             if (!prop.Flags.HasFlag(PropertyFlags.AllowsFiltering) || !prop.AccessMode.HasFlag(HttpMethod.Get))
             {
                 throw CreateParseException(currentNode,
-                                           "Property " + prop.JsonName + " is not allowed for query.",
+                                           $"Property {prop.JsonName} is not allowed for query.",
                                            errorReason : QueryParseErrorReason.MemberNotAllowedInQuery,
                                            memberName : prop.JsonName);
             }
@@ -146,21 +146,23 @@ namespace Pomona.Queries
                 var index = 0;
                 foreach (var elementValue in arrayElements.OfType<ConstantExpression>().Select(x => x.Value))
                     array.SetValue(elementValue, index++);
+
                 return Expression.Constant(array);
             }
 
             // Box value elements
             if (elementType == typeof(object))
             {
-                arrayElements =
-                    arrayElements.Select(x => x.Type.IsValueType ? Expression.Convert(x, elementType) : x).ToList();
+                arrayElements = arrayElements
+                    .Select(x => x.Type.IsValueType ? Expression.Convert(x, elementType) : x)
+                    .ToList();
             }
 
             return Expression.NewArrayInit(elementType, arrayElements);
         }
 
 
-        private Expression ParseBinaryOperator(BinaryOperatorNode binaryOperatorNode, Expression memberExpression)
+        private Expression ParseBinaryOperator(BinaryOperatorNode binaryOperatorNode)
         {
             var rightNode = binaryOperatorNode.Right;
             var leftNode = binaryOperatorNode.Left;
@@ -172,8 +174,7 @@ namespace Pomona.Queries
                     var origCallNode = (MethodCallNode)rightNode;
                     // Rewrite extension method call to static method call of tree:
                     // We do this by taking inserting the first node before arg nodes of extension method call.
-                    var staticMethodArgs = leftNode.WrapAsEnumerable()
-                                                   .Concat(rightNode.Children);
+                    var staticMethodArgs = leftNode.WrapAsEnumerable().Concat(rightNode.Children);
                     var staticMethodCall = new MethodCallNode(origCallNode.Name, staticMethodArgs);
 
                     return ParseExpression(staticMethodCall);
@@ -187,8 +188,7 @@ namespace Pomona.Queries
                 if (rightNode.NodeType != NodeType.TypeNameLiteral)
                     throw CreateParseException(binaryOperatorNode, "Right side of as operator is required to be a type literal.");
 
-                return Expression.TypeAs(ParseExpression(leftNode),
-                                         ResolveType((TypeNameNode)rightNode));
+                return Expression.TypeAs(ParseExpression(leftNode), ResolveType((TypeNameNode)rightNode));
             }
             if (binaryOperatorNode.NodeType == NodeType.In)
                 return ParseInOperator(binaryOperatorNode);
@@ -229,8 +229,7 @@ namespace Pomona.Queries
                 case NodeType.CaseInsensitiveEqual:
                     return ParseCaseInsensitiveEqualOperator(leftChild, rightChild);
                 default:
-                    throw new NotImplementedException(
-                        "Don't know how to handle node type " + binaryOperatorNode.NodeType);
+                    throw new NotImplementedException($"Don't know how to handle node type {binaryOperatorNode.NodeType}.");
             }
         }
 
@@ -255,13 +254,11 @@ namespace Pomona.Queries
 
         private Expression ParseCaseInsensitiveEqualOperator(Expression leftChild, Expression rightChild)
         {
+            var ignoreCase = Expression.Constant(StringComparison.InvariantCultureIgnoreCase);
+            var comparisonTypeMethod = QueryFunctionMapping.StringEqualsTakingComparisonTypeMethod;
             return ParseBinaryOperator(leftChild,
                                        rightChild,
-                                       (l, r) =>
-                                           Expression.Call(QueryFunctionMapping.StringEqualsTakingComparisonTypeMethod,
-                                                           l,
-                                                           r,
-                                                           Expression.Constant(StringComparison.InvariantCultureIgnoreCase)));
+                                       (l, r) => Expression.Call(comparisonTypeMethod, l, r, ignoreCase));
         }
 
 
@@ -280,9 +277,7 @@ namespace Pomona.Queries
             if (ifTrue.Type != ifFalse.Type)
                 PeformImplicitConversionForNodePair(ref ifTrue, ref ifFalse);
 
-            expression = Expression.Condition(testExpr,
-                                              ifTrue,
-                                              ifFalse);
+            expression = Expression.Condition(testExpr, ifTrue, ifFalse);
         }
 
 
@@ -302,8 +297,10 @@ namespace Pomona.Queries
 
             if (node.NodeType == NodeType.Symbol)
             {
-                var dictionaryInterface =
-                    memberExpression.Type.GetInterfacesOfGeneric(typeof(IDictionary<,>)).FirstOrDefault();
+                var dictionaryInterface = memberExpression.Type
+                                                          .GetInterfacesOfGeneric(typeof(IDictionary<,>))
+                                                          .FirstOrDefault();
+
                 if (node.Children.Count == 0 && dictionaryInterface != null)
                     return ResolveDictionaryAccess((SymbolNode)node, memberExpression, dictionaryInterface);
 
@@ -313,7 +310,7 @@ namespace Pomona.Queries
             var binaryOperatorNode = node as BinaryOperatorNode;
 
             if (binaryOperatorNode != null)
-                return ParseBinaryOperator(binaryOperatorNode, memberExpression);
+                return ParseBinaryOperator(binaryOperatorNode);
 
             if (node.NodeType == NodeType.GuidLiteral)
             {
@@ -357,7 +354,7 @@ namespace Pomona.Queries
             if (node.NodeType == NodeType.Lambda)
             {
                 var lambdaNode = (LambdaNode)node;
-                return ParseLambda(lambdaNode, memberExpression, expectedType);
+                return ParseLambda(lambdaNode, expectedType);
             }
 
             if (node.NodeType == NodeType.Not)
@@ -433,13 +430,12 @@ namespace Pomona.Queries
         }
 
 
-        private Expression ParseLambda(LambdaNode lambdaNode, Expression memberExpression, Type expectedType)
+        private Expression ParseLambda(LambdaNode lambdaNode, Type expectedType)
         {
             if (expectedType.UniqueToken() == typeof(Expression<>).UniqueToken())
             {
                 // Quote if expression
-                return Expression.Quote(
-                    ParseLambda(lambdaNode, memberExpression, expectedType.GetGenericArguments()[0]));
+                return Expression.Quote(ParseLambda(lambdaNode, expectedType.GetGenericArguments()[0]));
             }
 
             var nestedConverter = new NodeTreeToExpressionConverter(this.propertyResolver, this.parsedString);
@@ -456,9 +452,10 @@ namespace Pomona.Queries
             var funcTypeArgs = expectedType.GetGenericArguments();
 
             // TODO: Support multiple lambda args..(?)
-            var lambdaParams =
-                lambdaNode.Argument.WrapAsEnumerable().Select(
-                    (x, idx) => Expression.Parameter(funcTypeArgs[idx], x.Name)).ToList();
+            var lambdaParams = lambdaNode.Argument
+                                         .WrapAsEnumerable()
+                                         .Select((x, idx) => Expression.Parameter(funcTypeArgs[idx], x.Name))
+                                         .ToList();
 
             return nestedConverter.ToLambdaExpression(this.thisParam, lambdaParams, this.parameters.Values, lambdaNode.Body);
         }
@@ -468,22 +465,24 @@ namespace Pomona.Queries
         {
             if (memberExpression == null)
                 throw new ArgumentNullException(nameof(memberExpression));
+
             if (memberExpression == this.thisParam)
             {
                 if (node.HasArguments)
                 {
                     Expression expression;
-                    if (TryResolveOdataExpression(node, memberExpression, out expression))
+                    if (TryResolveOdataExpression(node, out expression))
                         return expression;
                 }
             }
+
             throw CreateParseException(node, "Could not recognize method " + node.Name);
         }
 
 
-        private void PeformImplicitConversionForNodePair(ref Expression left,
-                                                         ref Expression right,
-                                                         bool callSwappedRecursively = true)
+        private static void PeformImplicitConversionForNodePair(ref Expression left,
+                                                                ref Expression right,
+                                                                bool callSwappedRecursively = true)
         {
             var leftType = left.Type;
 
@@ -505,7 +504,7 @@ namespace Pomona.Queries
         }
 
 
-        private Expression ResolveDictionaryAccess(SymbolNode node, Expression memberExpression, Type dictionaryType)
+        private static Expression ResolveDictionaryAccess(SymbolNode node, Expression memberExpression, Type dictionaryType)
         {
             var key = node.Name;
 
@@ -544,7 +543,7 @@ namespace Pomona.Queries
         }
 
 
-        private void TryDetectAndConvertEnumComparison(ref Expression left, ref Expression right, bool tryAgainSwapped)
+        private static void TryDetectAndConvertEnumComparison(ref Expression left, ref Expression right, bool tryAgainSwapped)
         {
             if (left.Type.IsEnum && right.NodeType == ExpressionType.Constant && right.Type == typeof(string))
             {
@@ -552,9 +551,8 @@ namespace Pomona.Queries
                 var enumUnderlyingType = enumType.GetEnumUnderlyingType();
                 left = Expression.Convert(left, enumUnderlyingType);
                 var enumStringValue = (string)((ConstantExpression)right).Value;
-                var enumIntvalue = Convert.ChangeType(
-                    Enum.Parse(enumType, enumStringValue),
-                    enumUnderlyingType);
+                var enumValue = Enum.Parse(enumType, enumStringValue);
+                var enumIntvalue = Convert.ChangeType(enumValue, enumUnderlyingType);
                 right = Expression.Constant(enumIntvalue, enumUnderlyingType);
                 return;
             }
@@ -564,19 +562,20 @@ namespace Pomona.Queries
         }
 
 
-        private void TryDetectAndConvertNullableEnumComparison(ref Expression left, ref Expression right, bool tryAgainSwapped)
+        private static void TryDetectAndConvertNullableEnumComparison(ref Expression left, ref Expression right, bool tryAgainSwapped)
         {
             Type[] nullableTypeArgs;
-            if (right.NodeType == ExpressionType.Constant && right.Type == typeof(string)
-                && left.Type.TryExtractTypeArguments(typeof(Nullable<>), out nullableTypeArgs) && nullableTypeArgs[0].IsEnum)
+            if (right.NodeType == ExpressionType.Constant
+                && right.Type == typeof(string)
+                && left.Type.TryExtractTypeArguments(typeof(Nullable<>), out nullableTypeArgs)
+                && nullableTypeArgs[0].IsEnum)
             {
                 var enumType = nullableTypeArgs[0];
                 var enumUnderlyingType = typeof(Nullable<>).MakeGenericType(enumType.GetEnumUnderlyingType());
                 left = Expression.Convert(left, enumUnderlyingType);
                 var enumStringValue = (string)((ConstantExpression)right).Value;
-                var enumIntvalue = Convert.ChangeType(
-                    Enum.Parse(enumType, enumStringValue),
-                    enumType);
+                var enumValue = Enum.Parse(enumType, enumStringValue);
+                var enumIntvalue = Convert.ChangeType(enumValue, enumType);
                 right = Expression.Convert(Expression.Constant(enumIntvalue, enumType), enumUnderlyingType);
                 return;
             }
@@ -586,11 +585,11 @@ namespace Pomona.Queries
         }
 
 
-        private bool TryResolveGenericInstanceMethod<TMemberInfo>(Expression instance, ref TMemberInfo member)
+        private static bool TryResolveGenericInstanceMethod<TMemberInfo>(Expression instance, ref TMemberInfo member)
             where TMemberInfo : MemberInfo
         {
             var declaringType = member.DeclaringType;
-            if (declaringType.IsGenericTypeDefinition)
+            if (declaringType?.IsGenericTypeDefinition == true)
             {
                 Type[] typeArgs;
                 if (instance.Type.TryExtractTypeArguments(declaringType, out typeArgs))
@@ -612,10 +611,9 @@ namespace Pomona.Queries
         }
 
 
-        private bool TryResolveMemberMapping(
-            QueryFunctionMapping.MemberMapping memberMapping,
-            MethodCallNode node,
-            out Expression expression)
+        private bool TryResolveMemberMapping(QueryFunctionMapping.MemberMapping memberMapping,
+                                             MethodCallNode node,
+                                             out Expression expression)
         {
             expression = null;
             var reorderedArgs = memberMapping.ReorderArguments(node.Children);
@@ -638,7 +636,7 @@ namespace Pomona.Queries
                 if (methodParameters.Length != reorderedArgs.Count - argArrayOffset)
                 {
                     var message =
-                        $"Number parameters count ({methodParameters.Length}) for method {method.DeclaringType.FullName}.{method.Name} does not match provided argument count ({(reorderedArgs.Count - argArrayOffset)})";
+                        $"Number parameters count ({methodParameters.Length}) for method {method.DeclaringType?.FullName}.{method.Name} does not match provided argument count ({reorderedArgs.Count - argArrayOffset})";
                     throw CreateParseException(node, message);
                 }
 
@@ -704,10 +702,7 @@ namespace Pomona.Queries
         }
 
 
-        private bool TryResolveOdataExpression(
-            MethodCallNode node,
-            Expression memberExpression,
-            out Expression expression)
+        private bool TryResolveOdataExpression(MethodCallNode node, out Expression expression)
         {
             expression = null;
 
@@ -715,9 +710,9 @@ namespace Pomona.Queries
             {
                 case "isof":
                 case "cast":
-                    //var 
                     if (node.Children.Count > 2 || node.Children.Count < 1)
                         throw CreateParseException(node, "Only one or two arguments to cast operator is allowed.");
+
                     TypeNameNode castTypeArg;
                     Expression operand;
 

--- a/app/Pomona/Queries/NodeType.cs
+++ b/app/Pomona/Queries/NodeType.cs
@@ -28,6 +28,7 @@ namespace Pomona.Queries
         GreaterThanOrEqual,
         LessThanOrEqual,
         DateTimeLiteral,
+        DateTimeOffsetLiteral,
         Dot,
         Modulo,
         NotEqual,

--- a/app/Pomona/Routing/PomonaEngine.cs
+++ b/app/Pomona/Routing/PomonaEngine.cs
@@ -22,6 +22,7 @@ namespace Pomona.Routing
         {
             if (session == null)
                 throw new ArgumentNullException(nameof(session));
+
             this.session = session;
         }
 
@@ -33,12 +34,13 @@ namespace Pomona.Routing
             if (modulePath == null)
                 throw new ArgumentNullException(nameof(modulePath));
 
-            HttpMethod httpMethod =
-                (HttpMethod)Enum.Parse(typeof(HttpMethod), context.Request.Method, true);
-
+            var httpMethod = (HttpMethod)Enum.Parse(typeof(HttpMethod), context.Request.Method, true);
             var moduleRelativePath = context.Request.Path.Substring(modulePath.Length);
-            var request = new PomonaRequest(context.Request.Url.ToString(), moduleRelativePath, httpMethod,
-                                            context.Request.Headers, context.Request.Body,
+            var request = new PomonaRequest(context.Request.Url.ToString(),
+                                            moduleRelativePath,
+                                            httpMethod,
+                                            context.Request.Headers,
+                                            context.Request.Body,
                                             context.Request.Query);
 
             return this.session.Dispatch(request);

--- a/app/Pomona/Routing/QueryGetActionResolver.cs
+++ b/app/Pomona/Routing/QueryGetActionResolver.cs
@@ -45,19 +45,16 @@ namespace Pomona.Routing
         {
             var idProp = route.IdProperty;
             var idType = idProp.PropertyType;
-            return
-                pr =>
-                {
-                    var segmentValue = pr.Node.PathSegment.Parse(idType);
-                    return new PomonaResponse(pr,
-                                              pr.Node.Parent
-                                                .Query()
-                                                .WhereEx(
-                                                    ex =>
-                                                        ex.Apply(idProp.CreateGetterExpression)
-                                                        == Ex.Const(segmentValue, idType))
-                                                .WrapActionResult(QueryProjection.FirstOrDefault));
-                };
+            return pr =>
+            {
+                var segmentValue = pr.Node.PathSegment.Parse(idType);
+                var segmentExpression = Ex.Const(segmentValue, idType);
+                var whereExpression = pr.Node.Parent
+                                        .Query()
+                                        .WhereEx(ex => ex.Apply(idProp.CreateGetterExpression) == segmentExpression);
+                var queryableResult = whereExpression.WrapActionResult(QueryProjection.FirstOrDefault);
+                return new PomonaResponse(pr, queryableResult);
+            };
         }
 
 

--- a/tests/Pomona.Example/CritterDataSource.cs
+++ b/tests/Pomona.Example/CritterDataSource.cs
@@ -43,6 +43,7 @@ namespace Pomona.Example
         {
             if (typeof(T) == typeof(FailingThing))
                 throw new Exception("Stupid exception from failing thing;");
+
             if (typeof(T) == typeof(HandledThing) || typeof(T) == typeof(HandledChild))
             {
                 throw new InvalidOperationException(
@@ -50,7 +51,7 @@ namespace Pomona.Example
             }
 
             var newCritter = newObject as Critter;
-            if (newCritter != null && newCritter.Name != null && newCritter.Name.Length > 50)
+            if (newCritter?.Name?.Length > 50)
                 throw new ModelValidationException("Critter can't have name longer than 50 characters.");
 
             return this.store.Post(newObject);

--- a/tests/Pomona.Example/CritterRepository.cs
+++ b/tests/Pomona.Example/CritterRepository.cs
@@ -350,10 +350,14 @@ namespace Pomona.Example
                 }
                 return (IList<T>)list;
             }
+
             if (tt.ParentToChildProperty == null)
                 throw new InvalidOperationException("Expected a parent-child assosciation.");
-            var parents =
-                (IEnumerable<object>)getEntityListMethod.MakeGenericMethod(tt.ParentResourceType).Invoke(this, null);
+
+            var parents = (IEnumerable<object>)getEntityListMethod
+                .MakeGenericMethod(tt.ParentResourceType)
+                .Invoke(this, null);
+
             if (tt.ParentToChildProperty.PropertyType.IsCollection)
                 return parents.SelectMany(p => ((IEnumerable)tt.ParentToChildProperty.GetValue(p)).OfType<T>()).ToList();
             return parents.Select(p => (T)tt.ParentToChildProperty.GetValue(p)).ToList();
@@ -418,8 +422,7 @@ namespace Pomona.Example
         public object Patch<T>(T updatedObject)
         {
             var etagEntity = updatedObject as ISetEtaggedEntity;
-            if (etagEntity != null)
-                etagEntity.SetEtag(Guid.NewGuid().ToString());
+            etagEntity?.SetEtag(Guid.NewGuid().ToString());
 
             Save(updatedObject);
 

--- a/tests/Pomona.Example/CritterRepository.cs
+++ b/tests/Pomona.Example/CritterRepository.cs
@@ -100,6 +100,7 @@ namespace Pomona.Example
                 critter = new Critter();
 
             critter.CreatedOn = DateTime.UtcNow.AddDays(-rng.NextDouble() * 50.0);
+            critter.CreatedOnOffset = critter.CreatedOn;
 
             critter.Name = Words.GetAnimalWithPersonality(rng);
 
@@ -329,9 +330,13 @@ namespace Pomona.Example
         private Type GetBaseUriType<T>()
         {
             var transformedType = (StructuredType)TypeMapper.FromType<T>();
-            var mappedTypeInstance =
-                (transformedType.Maybe().OfType<ResourceType>().Select(x => (StructuredType)x.UriBaseType).OrDefault(
-                    () => transformedType)).Type;
+            var mappedTypeInstance = transformedType
+                .Maybe()
+                .OfType<ResourceType>()
+                .Select(x => (StructuredType)x.UriBaseType)
+                .OrDefault(() => transformedType)
+                .Type;
+
             return mappedTypeInstance;
         }
 
@@ -348,6 +353,7 @@ namespace Pomona.Example
                     list = new List<T>();
                     this.entityLists[type] = list;
                 }
+
                 return (IList<T>)list;
             }
 
@@ -360,6 +366,7 @@ namespace Pomona.Example
 
             if (tt.ParentToChildProperty.PropertyType.IsCollection)
                 return parents.SelectMany(p => ((IEnumerable)tt.ParentToChildProperty.GetValue(p)).OfType<T>()).ToList();
+
             return parents.Select(p => (T)tt.ParentToChildProperty.GetValue(p)).ToList();
         }
 
@@ -473,7 +480,15 @@ namespace Pomona.Example
             //var throwOnCalculatedPropertyVisitor = new ThrowOnCalculatedPropertyVisitor();
             //throwOnCalculatedPropertyVisitor.Visit(pq.FilterExpression);
 
-            return GetEntityList<TEntityBase>().OfType<TEntity>().AsQueryable();
+            var queryable = GetEntityList<TEntityBase>().OfType<TEntity>().AsQueryable();
+
+            /*if (typeof(TEntity) == typeof(Critter))
+            {
+                var createdOn = queryable.Cast<Critter>().Select(c => c.CreatedOnOffset).ToList();
+                Console.WriteLine(createdOn);
+            }*/
+
+            return queryable;
         }
 
 

--- a/tests/Pomona.Example/Models/Critter.cs
+++ b/tests/Pomona.Example/Models/Critter.cs
@@ -42,6 +42,8 @@ namespace Pomona.Example.Models
 
         public DateTime CreatedOn { get; set; }
 
+        public DateTimeOffset CreatedOnOffset { get; set; }
+
         /// <summary>
         /// List of <see cref="Critter"/> enemies.
         /// </summary>

--- a/tests/Pomona.IndependentClientTests/Pomona.IndependentClientTests.csproj
+++ b/tests/Pomona.IndependentClientTests/Pomona.IndependentClientTests.csproj
@@ -60,8 +60,8 @@
       <HintPath>..\..\packages\NuGet.Core.2.2.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/tests/Pomona.IndependentClientTests/packages.config
+++ b/tests/Pomona.IndependentClientTests/packages.config
@@ -7,5 +7,5 @@
   <package id="Nancy.Testing" version="1.4.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NuGet.Core" version="2.2.0" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit" version="3.5.0" targetFramework="net45" />
 </packages>

--- a/tests/Pomona.NHibernate3.Tests/NhQueryProviderCapabilityResolverTests.cs
+++ b/tests/Pomona.NHibernate3.Tests/NhQueryProviderCapabilityResolverTests.cs
@@ -48,8 +48,8 @@ namespace Pomona.NHibernate3.Tests
 
         #region Setup/Teardown
 
-        [TestFixtureSetUp]
-        public void FixtureSetUp()
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
         {
             this.sessionFactory = Fluently.Configure()
                                           .Database(CsharpSqliteConfiguration.Standard.InMemory)

--- a/tests/Pomona.NHibernate3.Tests/Pomona.NHibernate3.Tests.csproj
+++ b/tests/Pomona.NHibernate3.Tests/Pomona.NHibernate3.Tests.csproj
@@ -65,8 +65,8 @@
       <HintPath>..\..\packages\NHibernate.3.4.0.4000\lib\Net35\NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/tests/Pomona.NHibernate3.Tests/packages.config
+++ b/tests/Pomona.NHibernate3.Tests/packages.config
@@ -8,5 +8,5 @@
   <package id="Nancy" version="1.4.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NHibernate" version="3.4.0.4000" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit" version="3.5.0" targetFramework="net45" />
 </packages>

--- a/tests/Pomona.SystemTests.ClientCompatibility/ClientCompatibilityTests.cs
+++ b/tests/Pomona.SystemTests.ClientCompatibility/ClientCompatibilityTests.cs
@@ -29,14 +29,15 @@ namespace Pomona.SystemTests.ClientCompatibility
     public class ClientCompatibilityTests
     {
         [Test]
+        [Category("FailsOnFileShare")]
         public void All_references_from_old_assembly_are_valid()
         {
             var exceptions = new List<AssertionException>();
             try
             {
                 const string pomonaCommonAssemblyName = "Pomona.Common";
-                var clientAssembly = AssemblyDefinition.ReadAssembly(typeof(CritterClient).Assembly.CodeBaseAbsolutePath());
-                var pomonaCommonModule = AssemblyDefinition.ReadAssembly(typeof(IPomonaClient).Assembly.CodeBaseAbsolutePath()).MainModule;
+                var clientAssembly = AssemblyDefinition.ReadAssembly(typeof(CritterClient).Assembly.GetPhysicalLocation());
+                var pomonaCommonModule = AssemblyDefinition.ReadAssembly(typeof(IPomonaClient).Assembly.GetPhysicalLocation()).MainModule;
 
                 var typeReferences = clientAssembly.MainModule
                                                    .GetTypeReferences()

--- a/tests/Pomona.SystemTests.ClientCompatibility/Pomona.SystemTests.ClientCompatibility.csproj
+++ b/tests/Pomona.SystemTests.ClientCompatibility/Pomona.SystemTests.ClientCompatibility.csproj
@@ -55,8 +55,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/tests/Pomona.SystemTests.ClientCompatibility/packages.config
+++ b/tests/Pomona.SystemTests.ClientCompatibility/packages.config
@@ -3,5 +3,5 @@
   <package id="GitVersionTask" version="3.5.3" targetFramework="net451" developmentDependency="true" />
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
-  <package id="NUnit" version="2.6.4" targetFramework="net451" />
+  <package id="NUnit" version="3.5.0" targetFramework="net451" />
 </packages>

--- a/tests/Pomona.SystemTests.ConsoleAppRunner/Pomona.SystemTests.ConsoleAppRunner.csproj
+++ b/tests/Pomona.SystemTests.ConsoleAppRunner/Pomona.SystemTests.ConsoleAppRunner.csproj
@@ -44,8 +44,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/tests/Pomona.SystemTests.ConsoleAppRunner/Program.cs
+++ b/tests/Pomona.SystemTests.ConsoleAppRunner/Program.cs
@@ -25,7 +25,7 @@ namespace CritterClientTests.ConsoleAppRunner
 
             var critterTests = new CritterTests();
 
-            critterTests.FixtureSetUp();
+            critterTests.OneTimeSetUp();
 
             var tests = typeof(CritterTests).GetMethods().Select(
                 x => new
@@ -52,7 +52,7 @@ namespace CritterClientTests.ConsoleAppRunner
                 }
             }
 
-            critterTests.FixtureTearDown();
+            critterTests.OneTimeTearDown();
         }
     }
 }

--- a/tests/Pomona.SystemTests.ConsoleAppRunner/packages.config
+++ b/tests/Pomona.SystemTests.ConsoleAppRunner/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="GitVersionTask" version="3.5.3" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit" version="3.5.0" targetFramework="net45" />
 </packages>

--- a/tests/Pomona.SystemTests/ClientTestsBase.cs
+++ b/tests/Pomona.SystemTests/ClientTestsBase.cs
@@ -78,10 +78,12 @@ namespace Pomona.SystemTests
             Assert.That(callingMethod.Name, Does.StartWith("Query" + typeof(TEntity).Name));
 
             var allEntities = Repository.List<TEntity>();
-            var entities =
-                allEntities.Where(entityPredicate).OrderBy(x => x.Id).ToList();
+            var entities = allEntities.Where(entityPredicate).OrderBy(x => x.Id).ToList();
             var fetchedResources = Client.Query<TResource>().Where(resourcePredicate).ToList();
-            Assert.That(fetchedResources.Select(x => x.Id), Is.EquivalentTo(entities.Select(x => x.Id)), message);
+            var fetchedResourceIds = fetchedResources.Select(x => x.Id);
+            var entityIds = entities.Select(x => x.Id);
+
+            Assert.That(fetchedResourceIds, Is.EquivalentTo(entityIds), message);
 
             if (expectedResultCount.HasValue)
             {

--- a/tests/Pomona.SystemTests/ClientTestsBase.cs
+++ b/tests/Pomona.SystemTests/ClientTestsBase.cs
@@ -66,11 +66,10 @@ namespace Pomona.SystemTests
         }
 
 
-        public IList<TResource> TestQuery<TResource, TEntity>(
-            Expression<Func<TResource, bool>> resourcePredicate,
-            Func<TEntity, bool> entityPredicate,
-            string message = null,
-            int? expectedResultCount = null)
+        public IList<TResource> TestQuery<TResource, TEntity>(Expression<Func<TResource, bool>> resourcePredicate,
+                                                              Func<TEntity, bool> entityPredicate,
+                                                              string message = null,
+                                                              int? expectedResultCount = null)
             where TResource : IEntityBase
             where TEntity : EntityBase
         {

--- a/tests/Pomona.SystemTests/ClientTestsBase.cs
+++ b/tests/Pomona.SystemTests/ClientTestsBase.cs
@@ -76,7 +76,7 @@ namespace Pomona.SystemTests
         {
             var callingStackFrame = new StackFrame(1);
             var callingMethod = callingStackFrame.GetMethod();
-            Assert.That(callingMethod.Name, Is.StringStarting("Query" + typeof(TEntity).Name));
+            Assert.That(callingMethod.Name, Does.StartWith("Query" + typeof(TEntity).Name));
 
             var allEntities = Repository.List<TEntity>();
             var entities =

--- a/tests/Pomona.SystemTests/CodeGen/ClientGeneratedTypeTests.cs
+++ b/tests/Pomona.SystemTests/CodeGen/ClientGeneratedTypeTests.cs
@@ -250,7 +250,7 @@ namespace Pomona.SystemTests.CodeGen
         [Test]
         public void PeVerify_ClientWithEmbeddedPomonaCommon_HasExitCode0()
         {
-            var origDllPath = ClientAssembly.CodeBaseAbsolutePath();
+            var origDllPath = ClientAssembly.GetPhysicalLocation();
             var dllDir = Path.GetDirectoryName(origDllPath);
             var clientWithEmbeddedStuffName = Path.Combine(dllDir, "../../../../lib/IndependentCritters.dll");
             var newDllPath = Path.Combine(dllDir, "TempCopiedIndependentCrittersDll.tmp");
@@ -263,7 +263,7 @@ namespace Pomona.SystemTests.CodeGen
         [Test]
         public void PeVerify_HasExitCode0()
         {
-            PeVerify(typeof(ICritter).Assembly.CodeBaseAbsolutePath());
+            PeVerify(typeof(ICritter).Assembly.GetPhysicalLocation());
         }
 
 
@@ -271,7 +271,7 @@ namespace Pomona.SystemTests.CodeGen
         [Test(Description = "This test has been added since more errors are discovered when dll has been renamed.")]
         public void PeVerify_RenamedToAnotherDllName_StillHasExitCode0()
         {
-            var origDllPath = ClientAssembly.CodeBaseAbsolutePath();
+            var origDllPath = ClientAssembly.GetPhysicalLocation();
             Console.WriteLine(Path.GetDirectoryName(origDllPath));
             var newDllPath = Path.Combine(Path.GetDirectoryName(origDllPath), "TempCopiedClientLib.tmp");
             File.Copy(origDllPath, newDllPath, true);
@@ -284,7 +284,7 @@ namespace Pomona.SystemTests.CodeGen
         [Test]
         public void PomonaCommonHaveZeroReferencesToEmitNamespace()
         {
-            var assembly = AssemblyDefinition.ReadAssembly(ClientAssembly.CodeBaseAbsolutePath());
+            var assembly = AssemblyDefinition.ReadAssembly(ClientAssembly.GetPhysicalLocation());
             var trefs =
                 assembly.MainModule.GetTypeReferences().Where(x => x.Namespace == "System.Reflection.Emit").ToList();
             Assert.That(trefs, Is.Empty);

--- a/tests/Pomona.SystemTests/CodeGen/GeneratedClientDownloadTests.cs
+++ b/tests/Pomona.SystemTests/CodeGen/GeneratedClientDownloadTests.cs
@@ -32,11 +32,12 @@ namespace Pomona.SystemTests.CodeGen
 
 
         [Test]
+        [Category("FailsOnFileShare")]
         public void GetClientDll_ConfigurationIsCorrect_ReturnsClientDll()
         {
             var uri = new Uri(new Uri(Client.BaseUri), "Critters.Client.dll");
             var response = WebClient.SendSync(new HttpRequestMessage(HttpMethod.Get, uri));
-            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), $"Failed to download <{uri}>.");
             Assert.That(response.Content.Headers.ContentType.MediaType, Is.EqualTo("binary/octet-stream"));
             Assert.That(response.Content.Headers.ContentLength, Is.GreaterThan(0));
         }
@@ -53,11 +54,12 @@ namespace Pomona.SystemTests.CodeGen
 
 
         [Test]
+        [Category("FailsOnFileShare")]
         public void GetClientNupkg_ConfigurationIsCorrect_ReturnsClientNupkg()
         {
             var uri = new Uri(new Uri(Client.BaseUri), "client.nupkg");
             var response = WebClient.SendSync(new HttpRequestMessage(HttpMethod.Get, uri));
-            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), $"Failed to download <{uri}>.");
             Assert.That(response.Content.Headers.ContentType.MediaType, Is.EqualTo("application/zip"));
             Assert.That(response.Content.Headers.ContentLength, Is.GreaterThan(0));
         }

--- a/tests/Pomona.SystemTests/Handlers/HandlerMethodTests.cs
+++ b/tests/Pomona.SystemTests/Handlers/HandlerMethodTests.cs
@@ -52,7 +52,7 @@ namespace Pomona.SystemTests
         }
 
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Init()
         {
             this.nancyContext = new NancyContext();

--- a/tests/Pomona.SystemTests/Linq/LinqQueryTests.cs
+++ b/tests/Pomona.SystemTests/Linq/LinqQueryTests.cs
@@ -123,7 +123,7 @@ namespace Pomona.SystemTests.Linq
             // Should load uri when retrieving name
             var name = lazyCritter.Name;
             var afterLoadUri = ((IHasResourceUri)lazyCritter).Uri;
-            Assert.That(afterLoadUri, Is.Not.StringContaining(predicate));
+            Assert.That(afterLoadUri, Does.Not.Contain(predicate));
             Console.WriteLine(afterLoadUri);
             Assert.That(name, Is.EqualTo(expected.Name));
         }

--- a/tests/Pomona.SystemTests/Pomona.SystemTests.csproj
+++ b/tests/Pomona.SystemTests/Pomona.SystemTests.csproj
@@ -82,8 +82,8 @@
       <HintPath>..\..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/tests/Pomona.SystemTests/QueryCritterTests.cs
+++ b/tests/Pomona.SystemTests/QueryCritterTests.cs
@@ -29,6 +29,7 @@ namespace Pomona.SystemTests
             Repository.CreateRandomData(critterCount : 4, alwaysHasEnemies : true);
             var critterId = CritterEntities.OrderByDescending(x => x.Enemies.Count).Select(x => x.Id).First();
             var critterResource = Client.Critters.Get(critterId);
+
             Assert.That(critterResource.Enemies.IsLoaded(), Is.True);
             foreach (var enemy in critterResource.Enemies)
                 Assert.That(enemy.IsLoaded(), Is.False);
@@ -42,9 +43,8 @@ namespace Pomona.SystemTests
                 CritterEntities.OfType<MusicalCritter>().First();
             var bandName = firstMusicalCritter.BandName;
 
-            TestQuery<ICritter, Critter>(
-                x => x is IMusicalCritter && ((IMusicalCritter)x).BandName == bandName,
-                x => x is MusicalCritter && ((MusicalCritter)x).BandName == bandName);
+            TestQuery<ICritter, Critter>(x => x is IMusicalCritter && ((IMusicalCritter)x).BandName == bandName,
+                                         x => x is MusicalCritter && ((MusicalCritter)x).BandName == bandName);
         }
 
 
@@ -95,9 +95,8 @@ namespace Pomona.SystemTests
             {
                 x.Name = name;
             });
-            var results = TestQuery<ICritter, Critter>(
-                x => x.Name == name,
-                x => x.Name == name);
+            var results = TestQuery<ICritter, Critter>(x => x.Name == name,
+                                                       x => x.Name == name);
             Assert.That(results, Has.Count.EqualTo(1));
         }
 
@@ -127,9 +126,14 @@ namespace Pomona.SystemTests
         public void QueryCritter_OrderByThenBy_ReturnsCrittersInCorrectOrder()
         {
             Repository.CreateRandomData(40);
-            var fetchedCritters =
-                Client.Critters.Query().Expand(x => x.Weapons).OrderByDescending(x => x.Weapons.Count).ThenBy(x => x.Id)
-                      .Take(1000).ToList();
+            var fetchedCritters = Client.Critters
+                                        .Query()
+                                        .Expand(x => x.Weapons)
+                                        .OrderByDescending(x => x.Weapons.Count)
+                                        .ThenBy(x => x.Id)
+                                        .Take(1000)
+                                        .ToList();
+
             var expected = fetchedCritters.OrderByDescending(x => x.Weapons.Count).ThenBy(x => x.Id).ToList();
             Assert.That(fetchedCritters.SequenceEqual(expected));
         }
@@ -139,9 +143,14 @@ namespace Pomona.SystemTests
         public void QueryCritter_OrderByThenByDescending_ReturnsCrittersInCorrectOrder()
         {
             Repository.CreateRandomData(40);
-            var fetchedCritters =
-                Client.Critters.Query().Expand(x => x.Weapons).OrderBy(x => x.Weapons.Count).ThenByDescending(x => x.Id)
-                      .Take(1000).ToList();
+            var fetchedCritters = Client.Critters
+                                        .Query()
+                                        .Expand(x => x.Weapons)
+                                        .OrderBy(x => x.Weapons.Count)
+                                        .ThenByDescending(x => x.Id)
+                                        .Take(1000)
+                                        .ToList();
+
             var expected = fetchedCritters.OrderBy(x => x.Weapons.Count).ThenByDescending(x => x.Id).ToList();
             Assert.That(fetchedCritters.SequenceEqual(expected));
         }
@@ -197,9 +206,8 @@ namespace Pomona.SystemTests
         {
             var fromTime = DateTime.UtcNow.AddDays(-5);
             var toTime = DateTime.UtcNow.AddDays(-2);
-            TestQuery<ICritter, Critter>(
-                x => x.CreatedOn > fromTime && x.CreatedOn <= toTime,
-                x => x.CreatedOn > fromTime && x.CreatedOn <= toTime);
+            TestQuery<ICritter, Critter>(x => x.CreatedOn > fromTime && x.CreatedOn <= toTime,
+                                         x => x.CreatedOn > fromTime && x.CreatedOn <= toTime);
         }
 
 
@@ -225,9 +233,8 @@ namespace Pomona.SystemTests
 
             var critters = Client.Query<ICritter>(x => x.Id >= minId && x.Id <= maxId);
 
-            Assert.That(
-                critters.OrderBy(x => x.Id).Select(x => x.Id),
-                Is.EquivalentTo(orderedCritters.Select(x => x.Id)));
+            Assert.That(critters.OrderBy(x => x.Id).Select(x => x.Id),
+                        Is.EquivalentTo(orderedCritters.Select(x => x.Id)));
         }
 
 

--- a/tests/Pomona.SystemTests/QueryCritterTests.cs
+++ b/tests/Pomona.SystemTests/QueryCritterTests.cs
@@ -202,17 +202,17 @@ namespace Pomona.SystemTests
 
 
         [Test]
-        public void QueryCritter_WithDateBetween_ReturnsCorrectResult()
+        public void QueryCritter_WithDateTimeBetween_ReturnsCorrectResult()
         {
-            var fromTime = DateTime.UtcNow.AddDays(-5);
-            var toTime = DateTime.UtcNow.AddDays(-2);
-            TestQuery<ICritter, Critter>(x => x.CreatedOn > fromTime && x.CreatedOn <= toTime,
-                                         x => x.CreatedOn > fromTime && x.CreatedOn <= toTime);
+            var from = DateTime.UtcNow.AddDays(-5);
+            var to = DateTime.UtcNow.AddDays(-2);
+            TestQuery<ICritter, Critter>(x => x.CreatedOn > from && x.CreatedOn <= to,
+                                         x => x.CreatedOn > from && x.CreatedOn <= to);
         }
 
 
         [Test]
-        public void QueryCritter_WithDateEquals_ReturnsCorrectResult()
+        public void QueryCritter_WithDateTimeEquals_ReturnsCorrectResult()
         {
             var firstCritter = Repository.List<Critter>().First();
             var createdOn = firstCritter.CreatedOn;
@@ -226,10 +226,10 @@ namespace Pomona.SystemTests
         [Test]
         public void QueryCritter_WithDateTimeOffsetBetween_ReturnsCorrectResult()
         {
-            var fromTime = DateTimeOffset.Now.AddDays(-5);
-            var toTime = DateTimeOffset.Now.AddDays(-2);
-            TestQuery<ICritter, Critter>(x => x.CreatedOnOffset > fromTime && x.CreatedOnOffset <= toTime,
-                                         x => x.CreatedOnOffset > fromTime && x.CreatedOnOffset <= toTime);
+            var from = DateTimeOffset.Now.AddDays(-5);
+            var to = DateTimeOffset.Now.AddDays(-2);
+            TestQuery<ICritter, Critter>(x => x.CreatedOnOffset > from && x.CreatedOnOffset <= to,
+                                         x => x.CreatedOnOffset > from && x.CreatedOnOffset <= to);
         }
 
 

--- a/tests/Pomona.SystemTests/QueryCritterTests.cs
+++ b/tests/Pomona.SystemTests/QueryCritterTests.cs
@@ -224,6 +224,28 @@ namespace Pomona.SystemTests
 
 
         [Test]
+        public void QueryCritter_WithDateTimeOffsetBetween_ReturnsCorrectResult()
+        {
+            var fromTime = DateTimeOffset.Now.AddDays(-5);
+            var toTime = DateTimeOffset.Now.AddDays(-2);
+            TestQuery<ICritter, Critter>(x => x.CreatedOnOffset > fromTime && x.CreatedOnOffset <= toTime,
+                                         x => x.CreatedOnOffset > fromTime && x.CreatedOnOffset <= toTime);
+        }
+
+
+        [Test]
+        public void QueryCritter_WithDateTimeOffsetEquals_ReturnsCorrectResult()
+        {
+            var firstCritter = Repository.List<Critter>().First();
+            var createdOnOffset = firstCritter.CreatedOnOffset;
+            var fetchedCritter = Client.Query<ICritter>(x => x.CreatedOnOffset == createdOnOffset).ToList();
+
+            Assert.That(fetchedCritter, Has.Count.GreaterThanOrEqualTo(1));
+            Assert.That(fetchedCritter.First().Id, Is.EqualTo(firstCritter.Id));
+        }
+
+
+        [Test]
         public void QueryCritter_WithIdBetween_ReturnsCorrectResult()
         {
             var orderedCritters = CritterEntities.OrderBy(x => x.Id).Skip(2).Take(5).

--- a/tests/Pomona.SystemTests/QueryCritterTests.cs
+++ b/tests/Pomona.SystemTests/QueryCritterTests.cs
@@ -216,10 +216,8 @@ namespace Pomona.SystemTests
         {
             var firstCritter = Repository.List<Critter>().First();
             var createdOn = firstCritter.CreatedOn;
-            var fetchedCritter = Client.Query<ICritter>(x => x.CreatedOn == createdOn).ToList();
-
-            Assert.That(fetchedCritter, Has.Count.GreaterThanOrEqualTo(1));
-            Assert.That(fetchedCritter.First().Id, Is.EqualTo(firstCritter.Id));
+            TestQuery<ICritter, Critter>(x => x.CreatedOn == createdOn,
+                                         x => x.CreatedOn == createdOn);
         }
 
 
@@ -238,10 +236,8 @@ namespace Pomona.SystemTests
         {
             var firstCritter = Repository.List<Critter>().First();
             var createdOnOffset = firstCritter.CreatedOnOffset;
-            var fetchedCritter = Client.Query<ICritter>(x => x.CreatedOnOffset == createdOnOffset).ToList();
-
-            Assert.That(fetchedCritter, Has.Count.GreaterThanOrEqualTo(1));
-            Assert.That(fetchedCritter.First().Id, Is.EqualTo(firstCritter.Id));
+            TestQuery<ICritter, Critter>(x => x.CreatedOnOffset == createdOnOffset,
+                                         x => x.CreatedOnOffset == createdOnOffset);
         }
 
 

--- a/tests/Pomona.SystemTests/packages.config
+++ b/tests/Pomona.SystemTests/packages.config
@@ -8,6 +8,6 @@
   <package id="Nancy.Testing" version="1.4.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit" version="3.5.0" targetFramework="net45" />
   <package id="Storyteller" version="3.0.0.334-rc" targetFramework="net45" />
 </packages>

--- a/tests/Pomona.TestHelpers/Pomona.TestHelpers.csproj
+++ b/tests/Pomona.TestHelpers/Pomona.TestHelpers.csproj
@@ -51,8 +51,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/tests/Pomona.TestHelpers/SolutionTestsHelper.cs
+++ b/tests/Pomona.TestHelpers/SolutionTestsHelper.cs
@@ -18,6 +18,7 @@ using System.Xml.XPath;
 
 using NUnit.Framework;
 
+using Pomona.Common;
 using Pomona.Common.Internals;
 
 using Ude;
@@ -45,17 +46,11 @@ namespace Pomona.TestHelpers
             if (assembly == null)
                 throw new ArgumentNullException(nameof(assembly));
 
-            if (String.IsNullOrEmpty(assembly.CodeBase))
-                throw new ArgumentException($"The assembly '{assembly}' has no code base.", nameof(assembly));
-
-            UriBuilder uri = new UriBuilder(assembly.CodeBase);
-            string unescapeDataString = Uri.UnescapeDataString(uri.Path);
-            string assemblyPath = Path.GetFullPath(unescapeDataString);
+            var assemblyPath = assembly.GetPhysicalLocation();
 
             if (String.IsNullOrEmpty(assemblyPath))
             {
-                throw new FileNotFoundException(
-                    $"Could not find a physical path for '{assembly.CodeBase}'.");
+                throw new FileNotFoundException($"Could not find a physical path for '{assembly}'.");
             }
 
             FileInfo assemblyFile = new FileInfo(assemblyPath);

--- a/tests/Pomona.TestHelpers/packages.config
+++ b/tests/Pomona.TestHelpers/packages.config
@@ -5,6 +5,6 @@
   <package id="Nancy" version="1.4.1" targetFramework="net45" />
   <package id="Nancy.Testing" version="1.4.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit" version="3.5.0" targetFramework="net45" />
   <package id="UDE.CSharp" version="1.1.0" targetFramework="net45" />
 </packages>

--- a/tests/Pomona.UnitTests.GenerateClientDllApp/Extensions.cs
+++ b/tests/Pomona.UnitTests.GenerateClientDllApp/Extensions.cs
@@ -1,0 +1,54 @@
+﻿#region License
+
+// Pomona is open source software released under the terms of the LICENSE specified in the
+// project's repository, or alternatively at http://pomona.io/
+
+#endregion
+
+using System;
+
+using Mono.Cecil;
+
+namespace Pomona.UnitTests.GenerateClientDllApp
+{
+    internal static class Extensions
+    {
+        public static bool UnableToLoadAssemblyFromFileShare(this Exception exception, string assemblyFileName)
+        {
+            if (!(exception is AssemblyResolutionException))
+                return false;
+
+            return assemblyFileName.IsFileShare()
+                   || assemblyFileName.IsProbablyFileShare();
+        }
+
+
+        private static bool IsFileShare(this string path)
+        {
+            return path != null && path.StartsWith("\\\\");
+        }
+
+
+        private static bool IsProbablyFileShare(this string path)
+        {
+            if (path == null)
+                return false;
+
+            const int characterE = (int)'E';
+            const int haracterZ = (int)'Z';
+
+            for (var i = characterE; i <= haracterZ; i++)
+            {
+                var character = (char)i;
+                var stupidWindowsDriveLetterSequence = String.Concat(character, ":\\");
+
+                if (path.StartsWith(stupidWindowsDriveLetterSequence))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/tests/Pomona.UnitTests.GenerateClientDllApp/Pomona.UnitTests.GenerateClientDllApp.csproj
+++ b/tests/Pomona.UnitTests.GenerateClientDllApp/Pomona.UnitTests.GenerateClientDllApp.csproj
@@ -74,6 +74,7 @@
     <Compile Include="..\..\app\Shared\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Extensions.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/tests/Pomona.UnitTests.GenerateClientDllApp/Program.cs
+++ b/tests/Pomona.UnitTests.GenerateClientDllApp/Program.cs
@@ -116,6 +116,12 @@ namespace Pomona.UnitTests.GenerateClientDllApp
             }
             catch (Exception exception)
             {
+                if (exception.UnableToLoadAssemblyFromFileShare(dllName))
+                {
+                    Console.WriteLine($"ERROR! The file '{dllName}' seems to be pointing to a file share, which Mono.Cecil is unable to resolve during build time, for weird and unbeknownst reasons.");
+                    return 0;
+                }
+
                 Console.WriteLine(exception);
                 return 1;
             }

--- a/tests/Pomona.UnitTests/Client/CritterServiceTestsBase.cs
+++ b/tests/Pomona.UnitTests/Client/CritterServiceTestsBase.cs
@@ -56,8 +56,8 @@ namespace Pomona.UnitTests.Client
         public abstract TClient CreateInMemoryTestingClient(string baseUri, CritterBootstrapper critterBootstrapper);
 
 
-        [TestFixtureSetUp]
-        public void FixtureSetUp()
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
         {
             if (UseSelfHostedHttpServer)
             {
@@ -89,8 +89,8 @@ namespace Pomona.UnitTests.Client
         }
 
 
-        [TestFixtureTearDown]
-        public void FixtureTearDown()
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
         {
             TeardownRequestCompletedHandler();
 

--- a/tests/Pomona.UnitTests/Client/QueryPredicateBuilderTests.cs
+++ b/tests/Pomona.UnitTests/Client/QueryPredicateBuilderTests.cs
@@ -205,8 +205,8 @@ namespace Pomona.UnitTests.Client
         [Test]
         public void BuildDateTimeOffset_ReturnsCorrectString()
         {
-            var dt = new DateTimeOffset(2012, 10, 22, 5, 32, 45, TimeSpan.FromHours(5));
-            AssertBuild(x => x.BirthDayOffset == dt, "birthDayOffset eq datetime'2012-10-22T05:32:45+05:00'");
+            var dt = new DateTimeOffset(2012, 10, 22, 5, 32, 45, 123, TimeSpan.FromHours(5));
+            AssertBuild(x => x.BirthDayOffset == dt, "birthDayOffset eq datetime'2012-10-22T05:32:45.1230000+05:00'");
         }
 
 
@@ -214,7 +214,7 @@ namespace Pomona.UnitTests.Client
         public void BuildDateTimeOffsetUtc_ReturnsCorrectString()
         {
             var dt = new DateTimeOffset(2012, 10, 22, 5, 32, 45, TimeSpan.FromHours(0));
-            AssertBuild(x => x.BirthDayOffset == dt, "birthDayOffset eq datetime'2012-10-22T05:32:45+00:00'");
+            AssertBuild(x => x.BirthDayOffset == dt, "birthDayOffset eq datetime'2012-10-22T05:32:45.0000000+00:00'");
         }
 
 

--- a/tests/Pomona.UnitTests/Client/QueryPredicateBuilderTests.cs
+++ b/tests/Pomona.UnitTests/Client/QueryPredicateBuilderTests.cs
@@ -203,6 +203,22 @@ namespace Pomona.UnitTests.Client
 
 
         [Test]
+        public void BuildDateTimeOffset_ReturnsCorrectString()
+        {
+            var dt = new DateTimeOffset(2012, 10, 22, 5, 32, 45, TimeSpan.FromHours(5));
+            AssertBuild(x => x.BirthDayOffset == dt, "birthDayOffset eq datetime'2012-10-22T05:32:45+05:00'");
+        }
+
+
+        [Test]
+        public void BuildDateTimeOffsetUtc_ReturnsCorrectString()
+        {
+            var dt = new DateTimeOffset(2012, 10, 22, 5, 32, 45, TimeSpan.FromHours(0));
+            AssertBuild(x => x.BirthDayOffset == dt, "birthDayOffset eq datetime'2012-10-22T05:32:45+00:00'");
+        }
+
+
+        [Test]
         public void BuildDateTimeUtc_ReturnsCorrectString()
         {
             var dt = new DateTime(2012, 10, 22, 5, 32, 45, DateTimeKind.Utc);

--- a/tests/Pomona.UnitTests/Client/QueryPredicateBuilderTestsBase.cs
+++ b/tests/Pomona.UnitTests/Client/QueryPredicateBuilderTestsBase.cs
@@ -53,6 +53,7 @@ namespace Pomona.UnitTests.Client
 
         public class TestResource : IClientResource
         {
+            public DateTimeOffset BirthDayOffset { get; set; }
             public IDictionary<string, string> Attributes { get; set; }
             public DateTime Birthday { get; set; }
             public string Bonga { get; set; }

--- a/tests/Pomona.UnitTests/Documentation/XDocTests.cs
+++ b/tests/Pomona.UnitTests/Documentation/XDocTests.cs
@@ -13,6 +13,7 @@ using System.Xml.Linq;
 
 using NUnit.Framework;
 
+using Pomona.Common;
 using Pomona.Common.Internals;
 using Pomona.Documentation.Xml.Serialization;
 using Pomona.Example.Models;
@@ -46,9 +47,7 @@ namespace Pomona.UnitTests.Documentation
 
         private XDoc LoadXmlDoc()
         {
-            var uri = new UriBuilder(GetType().Assembly.CodeBase);
-            var unescapeDataString = Uri.UnescapeDataString(uri.Path);
-            var assemblyPath = Path.GetFullPath(unescapeDataString);
+            var assemblyPath = GetType().Assembly.GetPhysicalLocation();
             var assemblyFile = new FileInfo(assemblyPath);
             var xmlFilePath = Path.Combine(assemblyFile.DirectoryName, "Pomona.Example.xml");
             Assert.That(File.Exists(xmlFilePath), xmlFilePath + " does not exist");

--- a/tests/Pomona.UnitTests/ExceptionTests.cs
+++ b/tests/Pomona.UnitTests/ExceptionTests.cs
@@ -63,8 +63,8 @@ namespace Pomona.UnitTests
 
         #region Setup/Teardown
 
-        [TestFixtureSetUp]
-        public void FixtureSetUp()
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
         {
             var pomonaExceptions = typeof(UnknownTypeException).Assembly
                                                                .GetLoadableTypes()

--- a/tests/Pomona.UnitTests/Nuget/ClientNugetPackageBuilderTests.cs
+++ b/tests/Pomona.UnitTests/Nuget/ClientNugetPackageBuilderTests.cs
@@ -19,6 +19,7 @@ namespace Pomona.UnitTests.Nuget
     public class ClientNugetPackageBuilderTests : SessionTestsBase
     {
         [Test]
+        [Category("FailsOnFileShare")]
         public void BuildPackage_DoesNotThrowAnyExceptions()
         {
             var packageBuilder = new ClientNugetPackageBuilder(TypeMapper);

--- a/tests/Pomona.UnitTests/Pomona.UnitTests.csproj
+++ b/tests/Pomona.UnitTests/Pomona.UnitTests.csproj
@@ -88,8 +88,8 @@
       <HintPath>..\..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/tests/Pomona.UnitTests/Queries/ParseFilterTests.cs
+++ b/tests/Pomona.UnitTests/Queries/ParseFilterTests.cs
@@ -134,6 +134,18 @@ namespace Pomona.UnitTests.Queries
 
 
         [Test]
+        public void Parse_DateTimeOffsetConstant_CreatesCorrectExpression()
+        {
+            var dateTimeString = "2000-12-12T12:00+01:00";
+            var expectedTimeOffset = DateTimeOffset.Parse(dateTimeString);
+            var expr = this.parser.Parse<Dummy>($"TimeOffset eq datetime'{dateTimeString}'");
+            var binExpr = AssertCast<BinaryExpression>(expr.Body);
+            var leftTimeConstant = AssertIsConstant<DateTimeOffset>(binExpr.Right);
+            Assert.That(leftTimeConstant, Is.EqualTo(expectedTimeOffset));
+        }
+
+
+        [Test]
         public void Parse_DictAccess_CreatesCorrectExpression()
         {
             var expr = this.parser.Parse<Dummy>("attributes['foo'] eq 'bar'");

--- a/tests/Pomona.UnitTests/Queries/ParseSelectTests.cs
+++ b/tests/Pomona.UnitTests/Queries/ParseSelectTests.cs
@@ -57,8 +57,8 @@ namespace Pomona.UnitTests.Queries
         }
 
 
-        [TestFixtureSetUp]
-        public void TestFixtureSetUp()
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
         {
             // This is needed to get parser to use same anonymous types as those in expected expressions.
             AnonymousTypeBuilder.ScanAssemblyForExistingAnonymousTypes(GetType().Assembly);

--- a/tests/Pomona.UnitTests/Queries/QueryExpressionParserTestsBase.cs
+++ b/tests/Pomona.UnitTests/Queries/QueryExpressionParserTestsBase.cs
@@ -85,6 +85,7 @@ namespace Pomona.UnitTests.Queries
             public IList<string> SomeStrings { get; set; }
             public string Text { get; set; }
             public DateTime Time { get; set; }
+            public DateTimeOffset TimeOffset { get; set; }
             public object UnknownProperty { get; set; }
         }
 

--- a/tests/Pomona.UnitTests/Security/Authentication/PreAuthenticatedUriProviderTests.cs
+++ b/tests/Pomona.UnitTests/Security/Authentication/PreAuthenticatedUriProviderTests.cs
@@ -27,7 +27,7 @@ namespace Pomona.UnitTests.Security.Authentication
         [TestCase("http://bahahaha?existingParam=something",
             "http://bahahaha/?existingParam=something&$token=XYZ")]
         [TestCase("http://bahahaha?$token=something-else", "http://bahahaha/?$token=XYZ")]
-        [TestCase("/relative", "/relative/?$token=XYZ", Ignore = true, Category = "TODO")]
+        [TestCase("/relative", "/relative/?$token=XYZ", Ignore = "TODO", Category = "TODO")]
         public void CreatePreAuthenticatedUrl_AppendsSerializedUrlTokenToUrl(string url, string expectedResult)
         {
             var preAuthUrl = this.uriProvider.CreatePreAuthenticatedUrl(url);

--- a/tests/Pomona.UnitTests/Serialization/Json/PomonaJsonDeserializerTests.cs
+++ b/tests/Pomona.UnitTests/Serialization/Json/PomonaJsonDeserializerTests.cs
@@ -86,7 +86,7 @@ namespace Pomona.UnitTests.Serialization.Json
                     this.deserializer.DeserializeString("\"blahrg\"", options : new DeserializeOptions() { ExpectedBaseType = typeof(bool) }));
 
             // This will wrap a JsonSerializationException for now.
-            Assert.That(ex.Message, Is.StringStarting("Error converting value \"blahrg\" to type 'System.Boolean'."));
+            Assert.That(ex.Message, Does.StartWith("Error converting value \"blahrg\" to type 'System.Boolean'."));
             Assert.That(ex.InnerException, Is.InstanceOf<JsonSerializationException>());
         }
 

--- a/tests/Pomona.UnitTests/packages.config
+++ b/tests/Pomona.UnitTests/packages.config
@@ -8,5 +8,5 @@
   <package id="Nancy.Testing" version="1.4.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit" version="3.5.0" targetFramework="net45" />
 </packages>

--- a/tests/Pomona.UnitTests/packages.config
+++ b/tests/Pomona.UnitTests/packages.config
@@ -9,4 +9,5 @@
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.5.0" targetFramework="net45" />
+  <package id="NUnit.ConsoleRunner" version="3.5.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Disclaimer: This PR should ideally be 3 different ones, but I couldn't be bothered. The interesting stuff is in 88e91978f84d9a0705afa71950f6c00cba75a59f, where I try to implement query support for the `DateTimeOffset` type, by recognising the `+HH:mm` pattern in the `datetime` string in a query. If it matches the timezone pattern, it's a `DateTimeOffset`, if it doesn't, it's an old-school `DateTime`.

The only remaining thing to fix is that the following test fails:

```c#
namespace Pomona.SystemTests
{
    class Pomona.SystemTests.QueryCritterTests
    {
        [Test]
        public void QueryCritter_WithDateTimeOffsetEquals_ReturnsCorrectResult()
        {
            var firstCritter = Repository.List<Critter>().First();
            var createdOnOffset = firstCritter.CreatedOnOffset;
            var fetchedCritter = Client.Query<ICritter>(x => x.CreatedOnOffset == createdOnOffset).ToList();

            Assert.That(fetchedCritter, Has.Count.GreaterThanOrEqualTo(1));
            Assert.That(fetchedCritter.First().Id, Is.EqualTo(firstCritter.Id));
        }
    }
}
```

I've inspected the expression tree in the debugger, and both sides of the operand are of the type `DateTimeOffset`, and the test data matches the `createdOnOffset` used in the query, but it still doesn't return any results. Ideas?