### PR TITLE
Expose the PomonaHttpQueryTransformer

### DIFF
--- a/app/Pomona/PomonaSession.cs
+++ b/app/Pomona/PomonaSession.cs
@@ -29,6 +29,7 @@ namespace Pomona
         {
             if (factory == null)
                 throw new ArgumentNullException(nameof(factory));
+
             Factory = factory;
             this.container = container;
         }
@@ -41,7 +42,7 @@ namespace Pomona
 
             if (context.Session != this)
                 throw new ArgumentException("Request session is not same as this.");
-            
+
             var savedOuterContext = CurrentContext;
             try
             {
@@ -117,8 +118,8 @@ namespace Pomona
                     var actualResultType = node.ActualResultType;
                     // Reduce using input type difference
                     var validSelection = node.Children
-                            .Where(x => x.Route.InputType.IsAssignableFrom(actualResultType))
-                            .SingleOrDefaultIfMultiple();
+                                             .Where(x => x.Route.InputType.IsAssignableFrom(actualResultType))
+                                             .SingleOrDefaultIfMultiple();
                     if (validSelection == null)
                         throw new ResourceNotFoundException("No route alternative found due to conflict.");
                     node.SelectedChild = validSelection;
@@ -132,11 +133,8 @@ namespace Pomona
 
         private PomonaQuery ParseQuery(PomonaContext context, Type rootType, int? defaultPageSize = null)
         {
-            var queryPropertyResolver = new QueryTypeResolver(TypeMapper);
-            var queryExpressionParser = new QueryExpressionParser(queryPropertyResolver);
-            var queryTransformer = new PomonaHttpQueryTransformer(TypeMapper, queryExpressionParser);
             var structuredType = (ResourceType)TypeMapper.FromType(rootType);
-            return queryTransformer.TransformRequest(context, structuredType, defaultPageSize);
+            return this.GetQueryTransformer().TransformRequest(context, structuredType, defaultPageSize);
         }
 
 

--- a/app/Pomona/PomonaSessionExtensions.cs
+++ b/app/Pomona/PomonaSessionExtensions.cs
@@ -11,14 +11,29 @@ using System.Linq;
 using Nancy;
 using Nancy.Extensions;
 
+using Pomona.Queries;
 using Pomona.Routing;
 
 namespace Pomona
 {
+    /// <summary>
+    /// Extension methods for <see cref="IPomonaSession"/>
+    /// </summary>
     public static class PomonaSessionExtensions
     {
+        /// <summary>
+        /// Gets a <see cref="PomonaResponse"/> for the given <paramref name="url"/>.
+        /// </summary>
+        /// <param name="session">The <see cref="IPomonaSession"/> instance.</param>
+        /// <param name="url">The URL to create a <see cref="PomonaResponse"/> for.</param>
+        /// <returns>
+        /// A <see cref="PomonaResponse"/> for the given <paramref name="url"/>.
+        /// </returns>
         public static PomonaResponse Get(this IPomonaSession session, string url)
         {
+            if (session == null)
+                throw new ArgumentNullException(nameof(session));
+
             // TODO: Move this to some other class.
 
             string urlWithoutQueryPart = url;
@@ -33,6 +48,25 @@ namespace Pomona
             var relativePath = session.GetInstance<IUriResolver>().ToRelativePath(urlWithoutQueryPart);
             var req = new PomonaRequest(url, relativePath, query : query);
             return session.Dispatch(req);
+        }
+
+
+        /// <summary>
+        /// Gets a <see cref="PomonaHttpQueryTransformer"/> from the <paramref name="session"/>.
+        /// </summary>
+        /// <param name="session">The <see cref="IPomonaSession"/> from which to get a <see cref="PomonaHttpQueryTransformer"/>.</param>
+        /// <returns>
+        /// A <see cref="PomonaHttpQueryTransformer"/> from the <paramref name="session"/>.
+        /// </returns>
+        public static PomonaHttpQueryTransformer GetQueryTransformer(this IPomonaSession session)
+        {
+            if (session == null)
+                throw new ArgumentNullException(nameof(session));
+
+            var typeMapper = session.Factory.TypeMapper;
+            var queryPropertyResolver = new QueryTypeResolver(typeMapper);
+            var queryExpressionParser = new QueryExpressionParser(queryPropertyResolver);
+            return new PomonaHttpQueryTransformer(typeMapper, queryExpressionParser);
         }
 
 

--- a/tests/Pomona.UnitTests/PomonaModuleTests.cs
+++ b/tests/Pomona.UnitTests/PomonaModuleTests.cs
@@ -29,6 +29,16 @@ namespace Pomona.UnitTests
         }
 
 
+        [Test]
+        public void GetQueryTransformer_OnCreateSession_ReturnsQueryTransformer()
+        {
+            var session = new NoCustomDataSourceModule().CreateSession();
+            var queryTransformer = session.GetQueryTransformer();
+
+            Assert.That(queryTransformer, Is.Not.Null);
+        }
+
+
         public class Dummy
         {
             public int Id { get; set; }
@@ -60,6 +70,10 @@ namespace Pomona.UnitTests
         [PomonaConfiguration(typeof(NoCustomDataSourceConfiguration))]
         private class NoCustomDataSourceModule : PomonaModule
         {
+            public IPomonaSession CreateSession()
+            {
+                return new NoCustomDataSourceConfiguration().CreateSessionFactory().CreateSession(Container);
+            }
         }
     }
 }


### PR DESCRIPTION
Since the construction of a `PomonaHttpQueryTransformer` is currently a bit difficult, I've created an extension method on `IPomonaSession` that constructs it, so it can more easily be used anywhere you can get your hands on a `PomonaQuery` and want to do anything fun with it.